### PR TITLE
Emit "result", "workDone" and "timeout" events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+## [0.8.15] - 2024-06-04
+
+### Changed
+
+Added additional events to allow detailed monitoring on cache performance. Listen for them using `sifaka.on([event type], [callback])`
+
+These new events are:
+
+- `"result"`: Raised when the cache backend responds with a request. The "result" field of the event data will indicate whether it was a cache "hit" or cache "miss".
+- `"workDone"`: Raised whenever the workFunction has been called, either because of a cache miss or to refresh a stale value.
+- `"timeout"`: Raised whenever a request to the cache failed to be handled before timing out.
+
 ## [0.8.13] - 2017-07-17
 
 ### Changed

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ Sifaka.prototype.get = function (key, workFn, options, callback) {
             if(state.hit === true) {
                 self.stats.hit++;
                 self.debug(key, "CACHE HIT");
-                self.emit("result", {"result": "hit", "key": key, "data": data});
+                self.emit("result", {"result": "hit", "key": key, "options": options, "extra": extra});
 
                 if(options.metaOnly === "hit") {
                     // Pass "data" through here - so that we can verify in the tests that the backends are returning
@@ -124,7 +124,7 @@ Sifaka.prototype.get = function (key, workFn, options, callback) {
                 // check if we need to refresh the data in the background
                 if(state.stale) {
                     self.stats.stale++;
-                    self.emit("result", {"result": "stale", "key": key, "data": data});
+                    self.emit("result", {"result": "stale", "key": key, "options": options, "extra": extra});
                     if(!self._hasLocalLock(key)) {
                         self.backend.lock(key, null, function (err, acquired) {
                             if(acquired) {
@@ -141,7 +141,7 @@ Sifaka.prototype.get = function (key, workFn, options, callback) {
                 }
             } else {
                 self.stats.miss++;
-                self.emit("result", {"result": "miss", "key": key});
+                self.emit("result", {"result": "miss", "key": key, "options": options, "extra": extra});
                 if(options.metaOnly === "miss") {
                     // We don't need to wait for a result to be calculated, or trigger one
                     self.debug(key, "META ONLY CACHE MISS");
@@ -380,7 +380,7 @@ Sifaka.prototype._doWork = function (key, options, workFunction, state, callback
                             }, function (storedError, storedResult) {
                                 self._removeLocalLock(key);
                                 self._resolvePendingCallbacks(key, workError, data, extra, true, state);
-                                self.emit("workDone", {"key": key, "error": workError, "data": serializedData});
+                                self.emit("workDone", {"key": key, "error": workError, "options": options, "extra": serializedExtra});
                                 if(storedCallback) {
                                     storedCallback(storedError, storedResult);
                                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sifaka",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Sifaka is a pluggable caching library with an emphasis on protecting the backend from being overloaded.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows us to record detailed metrics on the cache hit rate for different keys.

I also noticed the "stale" metric wasn't initialised correctly so I fixed that too.